### PR TITLE
Change method syntax to support php7

### DIFF
--- a/components/modules/namecrane_mail/namecrane_mail.php
+++ b/components/modules/namecrane_mail/namecrane_mail.php
@@ -490,7 +490,7 @@ class NamecraneMail extends Module {
   }
 
   public function addService($package, array $vars = null, $parent_package = null, $parent_service = null, $status = 'pending') {
-    return $this->processService('create', $package, $vars, $parent_package, $parent_service);
+    return $this->processService('create', $package, null,  $vars, $parent_package, $parent_service);
   }
 
   public function editService($package, $service, array $vars = null, $parent_package = null, $parent_service = null) {

--- a/components/modules/namecrane_mail/namecrane_mail.php
+++ b/components/modules/namecrane_mail/namecrane_mail.php
@@ -490,11 +490,11 @@ class NamecraneMail extends Module {
   }
 
   public function addService($package, array $vars = null, $parent_package = null, $parent_service = null, $status = 'pending') {
-    return $this->processService('create', package: $package, vars: $vars, parent_package: $parent_package, parent_service: $parent_service);
+    return $this->processService('create', $package, $vars, $parent_package, $parent_service);
   }
 
   public function editService($package, $service, array $vars = null, $parent_package = null, $parent_service = null) {
-    return $this->processService('modify', package: $package, service: $service, vars: $vars, parent_package: $parent_package, parent_service: $parent_service);
+    return $this->processService('modify', $package, $service, $vars, $parent_package, $parent_service);
   }
 
   public function processService($action, $package, $service = null, array $vars = null, $parent_package = null, $parent_service = null) {


### PR DESCRIPTION
Hello
Thank you for providing reseller modules for Blesta. During the set up of the module, I found the module is using php8 syntax that might causing some problem for php7 webserver environment. I slightly modified the code to provide backward compatibility for php7.